### PR TITLE
Fix validated update

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -167,7 +167,7 @@ class PostController extends Controller
             ], 422);
         }
 
-        $post->update($request->only(['title', 'content', 'author_id']));
+        $post->update($validator->validated());
         return response()->json(['message' => 'Post updated', 'data' => $post]);
     }
 


### PR DESCRIPTION
## Summary
- ensure PostController only updates validated fields to avoid null updates

## Testing
- `php artisan test` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6842cdb7a7088320a771b80b2cbd1245