### PR TITLE
Integrate Laravel Sanctum

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,11 +6,12 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Laravel\Sanctum\HasApiTokens;
 
 class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable;
+    use HasApiTokens, HasFactory, Notifiable;
 
     /**
      * The attributes that are mass assignable.

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -12,7 +12,11 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
+        $middleware->web();
+        $middleware->api();
+
+        $middleware->appendToGroup('api', \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class);
+        $middleware->appendToGroup('api', 'auth:sanctum');
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         "darkaonline/l5-swagger": "^9.0",
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.10.1",
+        "laravel/sanctum": "^4.0",
         "zircote/swagger-php": "^5.1"
     },
     "require-dev": {

--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -1,0 +1,18 @@
+<?php
+
+return [
+    'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', sprintf(
+        '%s%s',
+        'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
+        env('APP_URL') ? ','.parse_url(env('APP_URL'), PHP_URL_HOST) : ''
+    ))),
+
+    'guard' => ['web'],
+
+    'expiration' => null,
+
+    'middleware' => [
+        'verify_csrf_token' => App\Http\Middleware\VerifyCsrfToken::class,
+        'encrypt_cookies' => App\Http\Middleware\EncryptCookies::class,
+    ],
+];

--- a/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
+++ b/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('personal_access_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('tokenable');
+            $table->string('name');
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('personal_access_tokens');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,5 +3,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\UserController;
 use App\Http\Controllers\PostController;
 
-Route::apiResource('users', UserController::class);
-Route::apiResource('posts', PostController::class);
+Route::middleware('auth:sanctum')->group(function () {
+    Route::apiResource('users', UserController::class);
+    Route::apiResource('posts', PostController::class);
+});


### PR DESCRIPTION
## Summary
- add `laravel/sanctum` dependency
- publish Sanctum config and migration
- enable Sanctum middleware in `bootstrap/app.php`
- use `HasApiTokens` trait on `User`
- protect API routes with `auth:sanctum`

## Testing
- `composer update` *(fails: command not found)*
- `php artisan vendor:publish --provider="Laravel\Sanctum\SanctumServiceProvider"` *(fails: command not found)*
- `php artisan migrate` *(fails: command not found)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842d70f6a748320b918870205343d92