### PR TITLE
Update README with login endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ Make sure your Laravel app is running and CORS settings allow local browser acce
 
 ## 🔗 API Endpoints
 
+- `POST /api/login` – authenticate and receive a token.
+
+Include `Authorization: Bearer <token>` in headers for protected routes.
+
 ### Users
 - `GET /api/users` - Get All User
 - `POST /api/users` - Create New User


### PR DESCRIPTION
## Summary
- document `/api/login` endpoint
- note about `Bearer <token>` authorization header for protected routes

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842e92e21548320a4ca59b9d3f2cea3